### PR TITLE
Add triangle to scene struct

### DIFF
--- a/src/hittable/mod.rs
+++ b/src/hittable/mod.rs
@@ -23,7 +23,6 @@ pub use triangle::Triangle;
 /// NOTE: This method can be used with entire acceleration structures or individual geometric
 /// objects. It doesn't matter, as long as you have some way to resolve which object was hit by an
 /// outgoing ray.
-#[enum_dispatch(SerializedHittable)]
 pub trait Hittable<T: GenFloat>: Debug + Send + Sync {
     /// A method that returns a hit record if the object was hit
     fn hit(&self, ray: &Ray<T>) -> Option<HitRecord<T>>;
@@ -33,10 +32,10 @@ pub trait Hittable<T: GenFloat>: Debug + Send + Sync {
 ///
 /// This is an enum type that exists for convenient use with serde, so we can create a serializable
 /// struct to expose as a scene description to the user.
-#[enum_dispatch]
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub enum SerializedHittable<T: GenFloat> {
     Sphere(Sphere<T>),
+    Triangle(triangle::TriangleParameters<T>),
 }
 
 /// Information pertaining to a ray intersection

--- a/src/hittable/triangle.rs
+++ b/src/hittable/triangle.rs
@@ -25,7 +25,7 @@ pub enum TriangleHandedness {
 ///
 /// These are the parameters for a triangle that may be input by a user. The initialization method
 /// will convert it into the `Triangle` struct, which can be used by the renderer at runtime.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub struct TriangleParameters<T: GenFloat> {
     /// The coordinates defining the bounds of the triangle in real-world space
     pub vertices: [Vector3<T>; 3],

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -80,6 +80,7 @@ where
                  }| {
                     let geometry: Box<dyn Hittable<T> + 'a> = match g {
                         SerializedHittable::Sphere(x) => Box::new(x.clone()),
+                        SerializedHittable::Triangle(x) => Box::new(x.init()),
                     };
                     let bsdf: Box<dyn BSDF<T> + 'a> = match m {
                         SerializedMaterial::Mirror(x) => Box::new(x.clone()),


### PR DESCRIPTION
Allow for the triangle primitive to be serialized and deserialized from
the user-defined scene struct.