### PR TITLE
Use thin LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ mimalloc = { version = "0.1", default-features = false }
 
 [profile.release]
 codegen-units = 1
-lto = true
+lto = "thin"


### PR DESCRIPTION
Use thin LTO instead of fat LTO to get similar performance gains in the binary but with a smaller memory footprint. This cuts the total build time in half.