### PR TITLE
Update dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ ron = "0.6"
 rayon = "1.4"
 mimalloc = { version = "0.1", default-features = false }
 
+[profile.dev]
+opt-level = 2 # some optimizations
+
 [profile.release]
 codegen-units = 1
 lto = "thin"


### PR DESCRIPTION
Update the default profile to utilize level 2 optimization so dev
builds are actually usable. Opt-level 0 leads to binaries that are too
slow to use for anything.
